### PR TITLE
chore: update workflow actions and fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Cache pnpm modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-pnpm-modules
         with:
@@ -36,9 +36,9 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
   
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2
         with:
-          version: 6.0.2
+          version: 8
           run_install: true
           
       - name: Get country code

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,14 +22,15 @@ export const run = async <T = unknown>(
     )
     return result
   } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error))
     spinner.fail(
       // eslint-disable-next-line no-nested-ternary
       typeof failText === 'undefined'
         ? text
         : typeof failText === 'function'
-        ? failText({ error, text })
+        ? failText({ error: err, text })
         : failText
     )
-    throw error
+    throw err
   }
 }


### PR DESCRIPTION
## Summary
- use newer GitHub Actions including cache v3 and checkout v4
- upgrade pnpm version used in CI
- handle unknown error types in run helper

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b55a7023248330b62d2a11eebfe19d